### PR TITLE
Team 10's tweaks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+﻿---
+# I prefer LLVM-style code but you can make your own format: <https://zed0.co.uk/clang-format-configurator/>
+BasedOnStyle: LLVM
+
+...

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,6 @@
 {
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": [
-        "platformio.platformio-ide",
-        "xaver.clang-format"
-    ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
-    ]
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["platformio.platformio-ide", "xaver.clang-format"],
+  "unwantedRecommendations": ["ms-vscode.cpptools-extension-pack"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
-    "C_Cpp.intelliSenseEngine": "Default",
-    "[cpp]": {
-        "editor.wordBasedSuggestions": false,
-        "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true,
-        "editor.defaultFormatter": "xaver.clang-format"
-    }
+  "[cpp]": {
+    "editor.defaultFormatter": "xaver.clang-format",
+    "editor.formatOnSave": true
+  }
 }

--- a/include/common.h
+++ b/include/common.h
@@ -1,0 +1,24 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+/**
+ * @brief tell the compiler that a parameter is deliberately unused
+ */
+#define UNUSED_PARAM(x) ((void)(x))
+
+/**
+ * @brief put a pin on PORTB into output mode
+ */
+#define PINB_OUT(p) DDRB |= (1 << (p))
+
+/**
+ * @brief set a pin on PORTB to HIGH
+ */
+#define PINB_ON(p) PORTB |= (1 << (p))
+
+/**
+ * @brief set a pin on PORTB to LOW
+ */
+#define PINB_OFF(p) PORTB &= ~(1 << (p))
+
+#endif

--- a/include/uart.h
+++ b/include/uart.h
@@ -1,12 +1,12 @@
 #ifndef UART_H
 #define UART_H
 
-#include <stdint.h>
 #include <avr/io.h>
+#include <stdint.h>
 
 /**
  * @brief initialise the UART peripheral.
- * 
+ *
  * @param baud baud rate to use.
  */
 void uart_init(uint32_t baud);
@@ -14,7 +14,7 @@ void uart_init(uint32_t baud);
 /**
  * @brief transmit a byte of data over UART, blocking until the data has
  * transferred.
- * 
+ *
  * @param data data to transfer.
  */
 void uart_transmit(uint8_t data);

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,17 +15,19 @@
 build_dir = build
 
 [env]
-; common config for all environments
+; Common config for all environments
 platform = atmelavr
 platform_packages =
     platformio/tool-simavr
 
 ; Select optimisation level and enable desired warnings (optional)
 ; You should customise this to your preference
+;
+; By default the following settings are set:
+;  - Maximum optimisations (will be disabled in debug mode)
+;  - All C warnings except -Wpedantic
 build_flags =
-	; maximum optimisation (will get disabled in debug mode)
-	-O3
-	; all C warnings except -Wpedantic
+    -O3
     -Wall -Wextra
     -Wcomment -Wdouble-promotion -Wfloat-conversion -Wfloat-equal
     -Wformat-nonliteral -Wformat-security -Wformat-signedness
@@ -89,8 +91,10 @@ upload_flags =
 upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
 
 [env:debug]
-build_type = debug	; include symbolic debugging information
+; Include symbolic debugging information
+build_type = debug
 board = ATmega328P
 
 [env:xplainedmini]
 board = ATmega328PB
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,9 +14,9 @@
 ; find our firmware in Proteus.
 build_dir = build
 
-[env:xplainedmini]
+[env]
+; common config for all environments
 platform = atmelavr
-board = ATmega328PB
 platform_packages =
     platformio/tool-simavr
 
@@ -76,3 +76,10 @@ upload_flags =
     -c
     xplainedmini
 upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
+
+[env:debug]
+build_type = debug	; include symbolic debugging information
+board = ATmega328P
+
+[env:xplainedmini]
+board = ATmega328PB

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,17 @@ platform = atmelavr
 platform_packages =
     platformio/tool-simavr
 
+; Select optimisation level and enable desired warnings (optional)
+; You should customise this to your preference
+build_flags =
+	; maximum optimisation (will get disabled in debug mode)
+	-O3
+	; all C warnings except -Wpedantic
+    -Wall -Wextra
+    -Wcomment -Wdouble-promotion -Wfloat-conversion -Wfloat-equal
+    -Wformat-nonliteral -Wformat-security -Wformat-signedness
+    -Wmissing-declarations -Wshadow -Wswitch-default
+
 ; The Xplained Mini boards you would have gotten from the ECE store have 2MHz
 ; clocks.
 board_build.f_cpu = 2000000UL

--- a/src/main.c
+++ b/src/main.c
@@ -3,25 +3,25 @@
 #include <avr/io.h>
 #include <util/delay.h>
 
+#include "common.h"
 #include "uart.h"
 
+/**
+ * @brief LED on the xplained mini board
+ */
 #define LED PB5
-
-#define PIN_OUT(p) DDRB |= (1 << (p))
-#define PIN_ON(p) PORTB |= (1 << (p))
-#define PIN_OFF(p) PORTB &= ~(1 << (p))
 
 int main(void) {
   uart_init(9600);
-  PIN_OUT(LED);
+  PINB_OUT(LED);
 
   while (1) {
     printf("on!\n");
-    PIN_ON(LED);
+    PINB_ON(LED);
     _delay_ms(1000);
 
     printf("off!\n");
-    PIN_OFF(LED);
+    PINB_OFF(LED);
     _delay_ms(1000);
   }
 }

--- a/src/uart.c
+++ b/src/uart.c
@@ -4,7 +4,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#define UNUSED_PARAMETER(x) ((void)(x))
+#define UNUSED_PARAMETER(x) ((void)(x)) // macro to notify compiler parameter is deliberately unused
 
 static int uart_debug_printf(char c, FILE *stream) {
   UNUSED_PARAMETER(stream);

--- a/src/uart.c
+++ b/src/uart.c
@@ -4,7 +4,10 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#define UNUSED_PARAMETER(x) ((void)(x))
+
 static int uart_debug_printf(char c, FILE *stream) {
+  UNUSED_PARAMETER(stream);
   uart_transmit((uint8_t)c);
   return 0;
 }

--- a/src/uart.c
+++ b/src/uart.c
@@ -1,17 +1,26 @@
 #include "uart.h"
+#include "common.h"
 
 #include <avr/io.h>
 #include <stdarg.h>
 #include <stdio.h>
 
-#define UNUSED_PARAMETER(x) ((void)(x)) // macro to notify compiler parameter is deliberately unused
-
+/**
+ * @brief print a single character over UART
+ *
+ * @param c character to print
+ * @param stream unused
+ * @return int
+ */
 static int uart_debug_printf(char c, FILE *stream) {
-  UNUSED_PARAMETER(stream);
+  UNUSED_PARAM(stream);
   uart_transmit((uint8_t)c);
   return 0;
 }
 
+/**
+ * @brief stdout handle for UART
+ */
 static FILE uart_stdout =
     FDEV_SETUP_STREAM(uart_debug_printf, NULL, _FDEV_SETUP_WRITE);
 


### PR DESCRIPTION
We made the following tweaks to the config in our team and found them useful. I don't know how useful they would be for the bare-bones class template, but I'll suggest them anyway.

### Separate environments
PlatformIO allows rapid switching between compilation environments using the bottom ribbon. Using seperate environments for debug (the ~P chip) and Xplained (the ~PB chip) is more convenient than changing the config file back and forth. It also makes it easy to build both, and eliminates the opportunity to build the wrong one (they'll make different files).

### Enable all warnings
We did this and it caught several bugs at compilation time. Warnings aren't everyone's cup of tea, but this is an easy way to enable them.