### PR TITLE
fix: :ambulance: use local installation of `avrdude` binary

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ upload_flags =
     $UPLOAD_PORT
     -c
     xplainedmini
-upload_command = avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
+upload_command = ${platformio.packages_dir}/tools-avrdude/avrdude $UPLOAD_FLAGS -U flash:w:$SOURCE:i
 
 [env:debug]
 ; Include symbolic debugging information


### PR DESCRIPTION
Changes the `upload_command` to PlatformIO's local installation of `avrdude`, rather than assuming it is available on the `PATH`.

Many students have been having errors with this 🙂